### PR TITLE
builtin type "unsigned long long"

### DIFF
--- a/luabind/detail/policy.hpp
+++ b/luabind/detail/policy.hpp
@@ -696,6 +696,7 @@ LUABIND_NUMBER_CONVERTER(signed int, integer)
 
 LUABIND_NUMBER_CONVERTER(unsigned int, number)
 LUABIND_NUMBER_CONVERTER(unsigned long, number)
+LUABIND_NUMBER_CONVERTER(unsigned long long, number)
 
 LUABIND_NUMBER_CONVERTER(signed long, integer)
 LUABIND_NUMBER_CONVERTER(float, number)

--- a/test/test_builtin_converters.cpp
+++ b/test/test_builtin_converters.cpp
@@ -31,6 +31,8 @@ void test_main(lua_State* L)
     LUABIND_TEST_BUILTIN(long, -1);
     LUABIND_TEST_BUILTIN(unsigned long, 1);
     LUABIND_TEST_BUILTIN(unsigned long, 2);
+    LUABIND_TEST_BUILTIN(unsigned long long, 1);
+    LUABIND_TEST_BUILTIN(unsigned long long, 2);
 
     LUABIND_TEST_BUILTIN(char, 1);
     LUABIND_TEST_BUILTIN(char, 2);


### PR DESCRIPTION
Hello!

When I trying to use a function, that returns unsigned long long, I get the error "unregistered class: St8auto_ptrIyE".
I think, it is good idea to add support of this type. Please, look at the patch, may be there is better way?
