### PR TITLE
Little fix for GCC4.7 support.

### DIFF
--- a/luabind/detail/call_function.hpp
+++ b/luabind/detail/call_function.hpp
@@ -419,7 +419,8 @@ typename detail::make_proxy<R, Args...>::type resume(
 
 #endif // LUABIND_CALL_FUNCTION_HPP_INCLUDED
 
-#elif BOOST_PP_ITERATION_FLAGS() == 1
+#else
+#if BOOST_PP_ITERATION_FLAGS() == 1
 
 #define LUABIND_TUPLE_PARAMS(z, n, data) const A##n *
 #define LUABIND_OPERATOR_PARAMS(z, n, data) const A##n & a##n
@@ -535,5 +536,6 @@ typename detail::make_proxy<R, Args...>::type resume(
 #undef LUABIND_TUPLE_PARAMS
 
 
+#endif
 #endif
 

--- a/luabind/detail/call_member.hpp
+++ b/luabind/detail/call_member.hpp
@@ -374,7 +374,8 @@ typename detail::make_member_proxy<R, Args...>::type call_member(
 
 #endif // LUABIND_CALL_MEMBER_HPP_INCLUDED
 
-#elif BOOST_PP_ITERATION_FLAGS() == 1
+#else
+#if BOOST_PP_ITERATION_FLAGS() == 1
 
 #define LUABIND_TUPLE_PARAMS(z, n, data) const A##n *
 #define LUABIND_OPERATOR_PARAMS(z, n, data) const A##n & a##n
@@ -417,5 +418,6 @@ typename detail::make_member_proxy<R, Args...>::type call_member(
 #undef LUABIND_OPERATOR_PARAMS
 #undef LUABIND_TUPLE_PARAMS
 
+#endif
 #endif
 

--- a/luabind/wrapper_base.hpp
+++ b/luabind/wrapper_base.hpp
@@ -133,7 +133,8 @@ namespace luabind
 
 #endif // LUABIND_WRAPPER_BASE_HPP_INCLUDED
 
-#elif BOOST_PP_ITERATION_FLAGS() == 1
+#else
+#if BOOST_PP_ITERATION_FLAGS() == 1
 
 #define LUABIND_TUPLE_PARAMS(z, n, data) const A##n *
 #define LUABIND_OPERATOR_PARAMS(z, n, data) const A##n & a##n
@@ -231,4 +232,5 @@ namespace luabind
 
 #undef N
 
+#endif
 #endif


### PR DESCRIPTION
Tested on Ubuntu quantal with gcc4.7 and boost 1.51

After a failure of my project's compilation on this platform (BOOST_PP_ITERATION_FLAGS gets evaluated to 0, thus generating an error for the bad syntax 0() ), I found out on http://dev.ryzom.com/issues/1462 that a patch existed and that it was not applied to the base repository, although it seems to be applied on the deb package.

The drawback being that macros such as LUABIND_TUPLE_PARAMS would not be available on platforms using this questionable gcc behaviour.

Details: https://svn.boost.org/trac/boost/ticket/6631
