### PR TITLE
Fix for Boost >= 1.49.

### DIFF
--- a/luabind/detail/call_function.hpp
+++ b/luabind/detail/call_function.hpp
@@ -419,7 +419,8 @@ typename detail::make_proxy<R, Args...>::type resume(
 
 #endif // LUABIND_CALL_FUNCTION_HPP_INCLUDED
 
-#elif BOOST_PP_ITERATION_FLAGS() == 1
+#else
+#if BOOST_PP_ITERATION_FLAGS() == 1
 
 #define LUABIND_TUPLE_PARAMS(z, n, data) const A##n *
 #define LUABIND_OPERATOR_PARAMS(z, n, data) const A##n & a##n
@@ -535,5 +536,6 @@ typename detail::make_proxy<R, Args...>::type resume(
 #undef LUABIND_TUPLE_PARAMS
 
 
+#endif
 #endif
 

--- a/luabind/detail/call_member.hpp
+++ b/luabind/detail/call_member.hpp
@@ -376,7 +376,8 @@ typename detail::make_member_proxy<R, Args...>::type call_member(
 
 #endif // LUABIND_CALL_MEMBER_HPP_INCLUDED
 
-#elif BOOST_PP_ITERATION_FLAGS() == 1
+#else
+#if BOOST_PP_ITERATION_FLAGS() == 1
 
 #define LUABIND_TUPLE_PARAMS(z, n, data) const A##n *
 #define LUABIND_OPERATOR_PARAMS(z, n, data) const A##n & a##n
@@ -419,5 +420,6 @@ typename detail::make_member_proxy<R, Args...>::type call_member(
 #undef LUABIND_OPERATOR_PARAMS
 #undef LUABIND_TUPLE_PARAMS
 
+#endif
 #endif
 

--- a/luabind/detail/object_rep.hpp
+++ b/luabind/detail/object_rep.hpp
@@ -24,6 +24,7 @@
 #ifndef LUABIND_OBJECT_REP_HPP_INCLUDED
 #define LUABIND_OBJECT_REP_HPP_INCLUDED
 
+#include <cstdlib>
 #include <boost/aligned_storage.hpp>
 #include <luabind/config.hpp>
 #include <luabind/detail/class_rep.hpp>

--- a/luabind/wrapper_base.hpp
+++ b/luabind/wrapper_base.hpp
@@ -133,7 +133,8 @@ namespace luabind
 
 #endif // LUABIND_WRAPPER_BASE_HPP_INCLUDED
 
-#elif BOOST_PP_ITERATION_FLAGS() == 1
+#else
+#if BOOST_PP_ITERATION_FLAGS() == 1
 
 #define LUABIND_TUPLE_PARAMS(z, n, data) const A##n *
 #define LUABIND_OPERATOR_PARAMS(z, n, data) const A##n & a##n
@@ -231,4 +232,5 @@ namespace luabind
 
 #undef N
 
+#endif
 #endif


### PR DESCRIPTION
This applies the Boost fix discussed here:

https://svn.boost.org/trac/boost/ticket/6631

And here:

http://thread.gmane.org/gmane.comp.lib.boost.devel/228802

With this fix, luabind should compile correctly with Boost 1.49+.
