### PR TITLE
Fix for non-functioning inheritance, due to bad ordering of parameters

### DIFF
--- a/src/inheritance.cpp
+++ b/src/inheritance.cpp
@@ -190,7 +190,7 @@ std::pair<void*, int> cast_graph::impl::cast(
         }
     }
 
-    m_cache.put(src, target, dynamic_id, object_offset, cache::invalid, -1);
+    m_cache.put(src, target, dynamic_id, object_offset, -1, cache::invalid);
 
     return std::pair<void*, int>((void*)0, -1);
 }


### PR DESCRIPTION
Did that long time ago, when I integrated luabind to The Secret World MMO.
It took me ages to figure it out where the problem was when the inherited functions didn't work.
Sent the fix directly to the creator of luabind around 2012, but just noticed that it isn't there yet.
Registered the inheritance using this luabind::class_<CLASS_NAME, CLASS_PARENT, luabind::detail::unspecified, luabind::detail::unspecified> BIND_CLASS_NAME;